### PR TITLE
feat: add support for aws-auth map_users

### DIFF
--- a/eks/eks.tf
+++ b/eks/eks.tf
@@ -21,9 +21,9 @@ module "amazon_eks" {
       max_capacity     = var.eks_max_capacity
       min_capacity     = var.eks_min_capacity
 
-      instance_types = [ var.eks_instance_type ]
+      instance_types = [var.eks_instance_type]
     }
   }
 
-  manage_aws_auth = false
+  map_users = var.map_users
 }

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -27,6 +27,15 @@ variable "kubernetes_version" {
   description = "version of K8s to install in the cluster"
 }
 
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+}
+
 variable "vpc_id" {
   description = "AWS id for the VPC to install the EKS cluster in"
 }

--- a/remote-backend.tf
+++ b/remote-backend.tf
@@ -6,24 +6,54 @@ terraform {
       name = "terraform-aws-eks"
     }
   }
-  required_version = ">= 1.0.0"
+  required_version = "~> 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.52.0"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.4.1"
+    }
+  }
 }
 
 provider "aws" {
   region = var.aws_region
 }
 
+provider "kubernetes" {
+  host = data.aws_eks_cluster.eks.endpoint
+
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.eks.token
+}
+
+data "aws_eks_cluster" "eks" {
+  name = module.eks.cluster_id
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  name = module.eks.cluster_id
+}
+
+
 module "eks" {
-    source = "./eks"
-    name   = "${var.aws_vpc_name}-eks-cluster"
+  source = "./eks"
+  name   = "${var.aws_vpc_name}-eks-cluster"
 
-    vpc_id          = var.vpc_id
-    private_subnets = var.private_subnets
+  vpc_id          = var.vpc_id
+  private_subnets = var.private_subnets
 
-    kubernetes_version = var.kubernetes_version
+  kubernetes_version = var.kubernetes_version
 
-    eks_min_capacity     = var.eks_min_capacity
-    eks_max_capacity     = var.eks_max_capacity
-    eks_desired_capacity = var.eks_desired_capacity
-    eks_instance_type    = var.eks_instance_type
+  eks_min_capacity     = var.eks_min_capacity
+  eks_max_capacity     = var.eks_max_capacity
+  eks_desired_capacity = var.eks_desired_capacity
+  eks_instance_type    = var.eks_instance_type
+
+  map_users = var.map_users
 }

--- a/template.auto.tfvars
+++ b/template.auto.tfvars
@@ -1,10 +1,22 @@
-cluster_name = "labs-eks-terratest-eks-cluster"
-aws_vpc_name = "labs-eks-terratest"
-aws_region = "ap-southeast-1"
-vpc_id = "vpc-0fc178a397554ab75" // Pre-provisioned test VPC, specifically for EKS tests.
-private_subnets = [ "subnet-000f3cf76c4b7782f", "subnet-077774cfd19cc9c7a", "subnet-0b5dcfd951cfaa94b" ]
-kubernetes_version = "1.20"
-eks_min_capacity = 1
-eks_max_capacity = 1
+cluster_name         = "labs-eks-terratest-eks-cluster"
+aws_vpc_name         = "labs-eks-terratest"
+aws_region           = "ap-southeast-1"
+vpc_id               = "vpc-0fc178a397554ab75" // Pre-provisioned test VPC, specifically for EKS tests.
+private_subnets      = ["subnet-000f3cf76c4b7782f", "subnet-077774cfd19cc9c7a", "subnet-0b5dcfd951cfaa94b"]
+kubernetes_version   = "1.20"
+eks_min_capacity     = 1
+eks_max_capacity     = 1
 eks_desired_capacity = 1
-eks_instance_type = "m5.large"
+eks_instance_type    = "m5.large"
+map_users = [
+  {
+    userarn  = "arn:aws:iam::033245014990:user/peter.griffin"
+    username = "peter.griffin"
+    groups   = ["system:masters"]
+  },
+  {
+    userarn  = "arn:aws:iam::033245014990:user/jai"
+    username = "jai"
+    groups   = ["system:masters"]
+  },
+]

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,15 @@ variable "kubernetes_version" {
   description = "version of K8s to install in the cluster"
 }
 
+variable "map_users" {
+  description = "Additional IAM users to add to the aws-auth configmap."
+  type = list(object({
+    userarn  = string
+    username = string
+    groups   = list(string)
+  }))
+}
+
 variable "private_subnets" {
   description = "A list of AWS subnet Ids, used to deploy the EKS cluster"
   type        = list(string)


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

* Exposes the `map_users` variable to support adding users to the `aws-auth` ConfigMap
