### PR TITLE
feat: add service account to aws-auth config map

### DIFF
--- a/eks/eks.tf
+++ b/eks/eks.tf
@@ -48,4 +48,5 @@ module "amazon_eks" {
   }
 
   map_users = var.map_users
+  map_roles = var.map_roles
 }

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -31,6 +31,15 @@ variable "map_users" {
   }))
 }
 
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth-configmap."
+  type = list(object({
+    rolearn = string
+    username = string
+    groups = list(string)
+  }))
+}
+
 variable "name" {
   description = "Name allocated to the EKS cluster"
 }

--- a/remote-backend.tf
+++ b/remote-backend.tf
@@ -40,7 +40,6 @@ data "aws_eks_cluster_auth" "eks" {
   name = module.eks.cluster_id
 }
 
-
 module "eks" {
   source = "./eks"
   name   = "${var.aws_vpc_name}-eks-cluster"
@@ -58,4 +57,6 @@ module "eks" {
   eks_instance_type    = var.eks_instance_type
 
   map_users = var.map_users
+  map_roles = var.map_roles
+
 }

--- a/template.auto.tfvars
+++ b/template.auto.tfvars
@@ -24,3 +24,11 @@ map_users = [
     groups   = ["system:masters"]
   },
 ]
+
+map_roles = [
+  {
+    rolearn  = "arn:aws:iam::124994850539:role/OrganizationAccountAccessRole"
+    username = "service-account"
+    groups   = ["system:masters"]
+  },
+]

--- a/test/aws-eks_test.go
+++ b/test/aws-eks_test.go
@@ -32,7 +32,14 @@ func TestTerraformAwsEKS(t *testing.T) {
 			"eks_max_capacity":     3,
 			"eks_desired_capacity": 3,
 			"eks_instance_type":    "m5.large",
-			"enable_irsa": true,
+			"enable_irsa": true
+			"map_roles": []map[string]interface{}{
+				{
+					"rolearn": "arn:aws:iam::124994850539:role/OrganizationAccountAccessRole",
+					"username": "service-account",
+					"groups": []string{"system:masters"},
+				},
+			},
 			"map_users": []map[string]interface{}{
 				{
 					"userarn": "arn:aws:iam::033245014990:user/peter.griffin",

--- a/test/aws-eks_test.go
+++ b/test/aws-eks_test.go
@@ -32,7 +32,7 @@ func TestTerraformAwsEKS(t *testing.T) {
 			"eks_max_capacity":     3,
 			"eks_desired_capacity": 3,
 			"eks_instance_type":    "m5.large",
-			"enable_irsa": true
+			"enable_irsa": true,
 			"map_roles": []map[string]interface{}{
 				{
 					"rolearn": "arn:aws:iam::124994850539:role/OrganizationAccountAccessRole",

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,15 @@ variable "kubernetes_version" {
   description = "version of K8s to install in the cluster"
 }
 
+variable "map_roles" {
+  description = "Additional IAM roles to add to the aws-auth configmap."
+  type = list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+}
+
 variable "map_users" {
   description = "Additional IAM users to add to the aws-auth configmap."
   type = list(object({


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

* Add cross-account role to aws-auth config map to allow AWS console access to EKS information when user switches role via OrganizationAccountAccessRole

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-eks/18)
<!-- Reviewable:end -->
