### PR TITLE
feat(outputs): add `cluster_security_group_id`

### DIFF
--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -18,6 +18,11 @@ output "cluster_primary_security_group_id" {
   value       = module.amazon_eks.cluster_primary_security_group_id
 }
 
+output "cluster_security_group_id" {
+  description = "A Security Group attached to the EKS cluster, shown as 'Additional security groups' in the EKS console"
+  value       = module.amazon_eks.cluster_security_group_id
+}
+
 output "eks-cluster-endpoint" {
   description = "The URI of the cluster endpoint, used for Admin tasks, i.e Kubectl"
   value       = data.aws_eks_cluster.eks-cluster.endpoint

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "cluster_primary_security_group_id" {
   value       = module.eks.cluster_primary_security_group_id
 }
 
+output "cluster_security_group_id" {
+  description = "A Security Group attached to the EKS cluster, shown as 'Additional security groups' in the EKS console"
+  value       = module.eks.cluster_security_group_id
+}
+
 output "eks-cluster-endpoint" {
   description = "The URI of the cluster endpoint, used for Admin tasks, i.e Kubectl"
   value       = module.eks.eks-cluster-endpoint


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.
-->

### Description

* Add the `cluster_security_group_id` output variable provided by the [upstream AWS terraform-aws-eks module's outputs](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest?tab=outputs)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-aws-eks/20)
<!-- Reviewable:end -->
